### PR TITLE
Fix for missing xml-parse-region function

### DIFF
--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -324,7 +324,9 @@
   (assert (not (string-equal "" pivotal-api-token)) nil "Please set pivotal-api-token: M-x customize-group RET pivotal RET"))
 
 (defun pivotal-get-xml-from-current-buffer ()
-  (let ((xml (cdr (xml-parse-fragment))))
+  (let ((xml (if (functionp 'xml-parse-fragment)
+                 (cdr (xml-parse-fragment))
+               (xml-parse-region))))
     (kill-buffer)
     xml))
 


### PR DESCRIPTION
Looks like the xml-parse-fragment function was removed from xml.el and
this fails in the latest versions of emacs24. Add a check to see if
the function is defined and use xml-parse-region otherwise for now.
