### PR TITLE
Integrate with Pivotal Tracker web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ or set it manually:
 * <kbd>M-x pivotal</kbd> will display a list of your current projects
 * <kbd>RET</kbd> or <kbd>.</kbd> will load the current iteration for the given project
 * <kbd>n</kbd> and <kbd>p</kbd> move between lines, like dired mode
+* <kbd>o</kbd> will open the given project in an external web browser
 
 ### Current Project View
 
@@ -48,6 +49,9 @@ or set it manually:
 * <kbd>T</kbd> will prompt for a new task
 * <kbd>F</kbd> will mark the task (not the story) under the cursor as finished
 * <kbd>+</kbd> adds a new story
+* <kbd>l</kbd> saves the url of the given story to the kill-ring (copies it)
+* <kbd>o</kbd> will open the given story in an exernal browser
+* <kbd>C-c o</kbd> will open the current project in an external browser
 
 ## Issues & Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ or set it manually:
 * <kbd>+</kbd> adds a new story
 * <kbd>l</kbd> saves the url of the given story to the kill-ring (copies it)
 * <kbd>o</kbd> will open the given story in an exernal browser
-* <kbd>p</kbd> will open the current project in an external browser
+* <kbd>C-o</kbd> will open the current project in an external browser
 
 ## Issues & Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ or set it manually:
 * <kbd>+</kbd> adds a new story
 * <kbd>l</kbd> saves the url of the given story to the kill-ring (copies it)
 * <kbd>o</kbd> will open the given story in an exernal browser
-* <kbd>C-c o</kbd> will open the current project in an external browser
+* <kbd>p</kbd> will open the current project in an external browser
 
 ## Issues & Feature Requests
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -208,6 +208,11 @@
   (interactive)
   (browse-url (pivotal-story-url-at-point)))
 
+(defun pivotal-open-current-project-in-browser ()
+  "asks a WWW browser to load the current project"
+  (interactive)
+  (browse-url (pivotal-get-project-url *pivotal-current-project*)))
+
 ;;;;;;;; CALLBACKS
 
 
@@ -325,6 +330,7 @@
   (define-key pivotal-mode-map (kbd "F") 'pivotal-check-task)
   (define-key pivotal-mode-map (kbd "l") 'pivotal-kill-ring-save-story-url)
   (define-key pivotal-mode-map (kbd "o") 'pivotal-open-story-in-browser)
+  (define-key pivotal-mode-map (kbd "C-c o") 'pivotal-open-current-project-in-browser)
   (setq font-lock-defaults '(pivotal-font-lock-keywords))
   (font-lock-mode))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -200,6 +200,13 @@
                'pivotal-check-task-callback
                (format "<task><complete>true</complete></task>")))
 
+(defun pivotal-kill-ring-save-story-url ()
+  "saves the external story URL as if killed, but don't kill anything"
+  (interactive)
+  (let ((story-url pivotal-story-url-at-point))
+    (kill-new story-url)
+    (message (concat "copied story URL to kill ring: " story-url))))
+
 ;;;;;;;; CALLBACKS
 
 
@@ -315,6 +322,7 @@
   (define-key pivotal-mode-map (kbd "T") 'pivotal-add-task)
   (define-key pivotal-mode-map (kbd "+") 'pivotal-add-story)
   (define-key pivotal-mode-map (kbd "F") 'pivotal-check-task)
+  (define-key pivotal-mode-map (kbd "l") 'pivotal-kill-ring-save-story-url)
   (setq font-lock-defaults '(pivotal-font-lock-keywords))
   (font-lock-mode))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -117,11 +117,7 @@
 (defun pivotal-set-project ()
   "set the current project, and load the current iteration for that project"
   (interactive)
-  (setq *pivotal-current-project*
-        (progn
-          (beginning-of-line)
-          (re-search-forward "\\([0-9]+\\)" (point-at-eol))
-          (match-string 1)))
+  (setq *pivotal-current-project* (pivotal-project-id-at-point))
   (pivotal-get-current))
 
 (defun pivotal-get-story (id)

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -551,6 +551,12 @@
     (string-match "pivotal-\\([0-9]+\\)" story-str)
     (match-string 1 story-str)))
 
+(defun pivotal-story-url-at-point (&optional position)
+  (replace-regexp-in-string "/services/v3/" "/n/"
+                            (pivotal-url
+                             "projects" *pivotal-current-project*
+                             "stories" (pivotal-story-id-at-point position))))
+
 (defun pivotal-task-id-at-point (&optional position)
   (save-excursion
     (beginning-of-line)

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -419,6 +419,12 @@
 
 (defvar pivotal-story-estimate-history '())
 
+(defun pivotal-project-id-at-point ()
+  (save-excursion
+    (beginning-of-line)
+    (re-search-forward "\\([0-9]+\\)" (point-at-eol))
+    (match-string 1)))
+
 (defun pivotal-project-member->member-name-id-association (project-member)
   `(,(cdr (assoc 'name (assoc 'person project-member)))
     .

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -207,6 +207,11 @@
     (kill-new story-url)
     (message (concat "copied story URL to kill ring: " story-url))))
 
+(defun pivotal-open-story-in-browser ()
+  "asks a WWW browser to load the story"
+  (interactive)
+  (browse-url (pivotal-story-url-at-point)))
+
 ;;;;;;;; CALLBACKS
 
 
@@ -323,6 +328,7 @@
   (define-key pivotal-mode-map (kbd "+") 'pivotal-add-story)
   (define-key pivotal-mode-map (kbd "F") 'pivotal-check-task)
   (define-key pivotal-mode-map (kbd "l") 'pivotal-kill-ring-save-story-url)
+  (define-key pivotal-mode-map (kbd "o") 'pivotal-open-story-in-browser)
   (setq font-lock-defaults '(pivotal-font-lock-keywords))
   (font-lock-mode))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -399,6 +399,11 @@
           (pivotal-get-project project-id)
         project))))
 
+(defun pivotal-get-project-url (project-id)
+  (replace-regexp-in-string "/services/v3/" "/n/"
+                            (pivotal-url
+                             "projects" project-id)))
+
 (defun pivotal-get-estimate-scale (project-id)
   (let* ((project             (pivotal-get-project project-id))
          (point-scale-str     (cdr (assoc 'point_scale project)))

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -213,6 +213,11 @@
   (interactive)
   (browse-url (pivotal-get-project-url *pivotal-current-project*)))
 
+(defun pivotal-open-project-at-point-in-browser ()
+  "asks a WWW browser to open the project at point"
+  (interactive)
+  (browse-url (pivotal-get-project-url (pivotal-project-id-at-point))))
+
 ;;;;;;;; CALLBACKS
 
 
@@ -343,6 +348,7 @@
   (define-key pivotal-project-mode-map (kbd "j") 'next-line)
   (define-key pivotal-project-mode-map (kbd "k") 'previous-line)
 
+  (define-key pivotal-project-mode-map (kbd "o") 'pivotal-open-project-at-point-in-browser)
   (define-key pivotal-project-mode-map (kbd ".") 'pivotal-set-project)
   (define-key pivotal-project-mode-map (kbd "C-m") 'pivotal-set-project))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -335,7 +335,7 @@
   (define-key pivotal-mode-map (kbd "F") 'pivotal-check-task)
   (define-key pivotal-mode-map (kbd "l") 'pivotal-kill-ring-save-story-url)
   (define-key pivotal-mode-map (kbd "o") 'pivotal-open-story-in-browser)
-  (define-key pivotal-mode-map (kbd "C-c o") 'pivotal-open-current-project-in-browser)
+  (define-key pivotal-mode-map (kbd "p") 'pivotal-open-current-project-in-browser)
   (setq font-lock-defaults '(pivotal-font-lock-keywords))
   (font-lock-mode))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -199,7 +199,7 @@
 (defun pivotal-kill-ring-save-story-url ()
   "saves the external story URL as if killed, but don't kill anything"
   (interactive)
-  (let ((story-url pivotal-story-url-at-point))
+  (let ((story-url (pivotal-story-url-at-point)))
     (kill-new story-url)
     (message (concat "copied story URL to kill ring: " story-url))))
 

--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -335,7 +335,7 @@
   (define-key pivotal-mode-map (kbd "F") 'pivotal-check-task)
   (define-key pivotal-mode-map (kbd "l") 'pivotal-kill-ring-save-story-url)
   (define-key pivotal-mode-map (kbd "o") 'pivotal-open-story-in-browser)
-  (define-key pivotal-mode-map (kbd "p") 'pivotal-open-current-project-in-browser)
+  (define-key pivotal-mode-map (kbd "C-o") 'pivotal-open-current-project-in-browser)
   (setq font-lock-defaults '(pivotal-font-lock-keywords))
   (font-lock-mode))
 


### PR DESCRIPTION
Adds these features:

* `pivotal-open-project-at-point-in-browser` (<kbd>o</kbd> in pivotal-project-mode)
* `pivotal-open-current-project-in-browser` (<kbd>C-c o</kbd> in pivotal-mode)
* `pivotal-open-story-in-browser` (<kbd>o</kbd> in pivotal-mode)
* `pivotal-kill-ring-save-story-url` (<kbd>l</kbd> in pivotal-mode)  
   saves the URL to your kill-ring / copies it to your clipboard

Also some light refactoring of functions related to these, in order to keep the code DRY.