### PR TITLE
Replace cl package with cl-lib

### DIFF
--- a/pivotal-tracker.el
+++ b/pivotal-tracker.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'xml)
 (require 'url)
 (require 'json)
@@ -546,7 +546,7 @@ ESTIMATE the story points estimation."
 
 (defun assert-pivotal-api-token ()
   "Notify the user if the `pivotal-api-token' is not set."
-  (assert (not (string-equal "" pivotal-api-token)) nil "Please set pivotal-api-token: M-x customize-group RET pivotal RET"))
+  (cl-assert (not (string-equal "" pivotal-api-token)) nil "Please set pivotal-api-token: M-x customize-group RET pivotal RET"))
 
 (defun pivotal-get-xml-from-current-buffer ()
   "Get Pivotal API XML from the current buffer."


### PR DESCRIPTION
cl.el was deprecated in favor of cl-lib.el in Emacs 24.3. cl-lib is identical
to cl.el except that it uses the cl-namespace for all its functions.

Thanks for pivotal tracker btw <3