### PR TITLE
Use AUTH-SOURCE to retrieve encrypted token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,18 @@ You can install via [MELPA](http://melpa.milkbox.net/#/pivotal-tracker)
 
 ## Initial Setup
 
-Before using the tracker you must setup your pivotal API key in
-Emacs. You can obtain the key from
-the [Profile](https://www.pivotaltracker.com/profile) link in the
-Pivotal Tracker web application.
+Before using the tracker you must store your Pivotal API key somewhere Emacs
+can find it. Because your API key is sensitive information it must not be
+stored in clear text. Using the [auth-source] library Emacs can retrieve your
+API key from `~/.authinfo.gpg`. Retrieve your API key from the
+[Profile](https://www.pivotaltracker.com/profile) page and add a new entry in
+`~/.authinfo.gpg`
 
-Once you have the key you can use **customize** to set it in Emacs.
-
-You'll have the option to save it or just use it for the current session.
-
-<kbd>M-x customize-group RET pivotal RET</kbd>
-
-You can also manually add it to your `.emacs.d` or `.spacemacs`, add
-the following `setq`:
-
-```elisp
-(setq pivotal-api-token "your-secret-token")
 ```
+machine pivotal-tracker.com password <your-api-key>
+```
+
+Once you've done that you'll be able to use `pivotal-tracker`.
 
 ## Usage
 


### PR DESCRIPTION
Instead of storing the token along with the rest of the users
customization, use the auth-source library so we can store the token in
an encrypted file instead.

Don't require CL-LIB anymore as we no longer need CL-ASSERT.

This is a backwards incompatible change as I prefer to not enable users to storing sensitive information in plain text, but could leave pivotal-token as customizable variable so the change is backwards compatible if you prefer.